### PR TITLE
Rename to Bundle Builder; add document index and theme toggle; always number cover

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Dossier Builder
+# Bundle Builder
 
-Dossier Builder is now a portable offline folder app built for Chromium-based browsers in locked-down environments.
+Bundle Builder is now a portable offline folder app built for Chromium-based browsers in locked-down environments.
 
 ## Folder contents
 

--- a/assets/app.css
+++ b/assets/app.css
@@ -55,6 +55,64 @@
 }
 
 :root {
+  --paper: #15181d;
+  --paper-2: #1b2027;
+  --paper-3: #232a33;
+  --card: #1c232d;
+  --code-bg: #262f3a;
+  --ink: #edf2f7;
+  --ink-2: #dde4ec;
+  --ink-mute: #a7b1bf;
+  --ink-soft: #8d98a8;
+  --ink-ghost: #556173;
+  --navy: #4b8ecb;
+  --navy-2: #3a79b1;
+  --navy-3: #2f6798;
+  --navy-tint: #1a2d42;
+  --slate: #95a2b5;
+  --danger: #ee7b73;
+  --danger-tint: #412120;
+  --warn: #e4af63;
+  --warn-tint: #3f311c;
+  --ok: #7ed89a;
+  --ok-tint: #1f3a2b;
+  --info: #7bb8ff;
+  --info-tint: #1a2d42;
+  --border: #2a3442;
+  --border-soft: #334053;
+  --border-strong: #4b5d76;
+  --font-slab: "Courier Prime", "Courier New", ui-monospace, monospace;
+  --font-sans: "IBM Plex Sans", "Segoe UI", system-ui, sans-serif;
+  --font-mono: "IBM Plex Mono", "Courier Prime", ui-monospace, monospace;
+  --fs-eyebrow: 12px;
+  --fs-small: 13px;
+  --fs-body: 14px;
+  --fs-h3: 20px;
+  --fs-h2: 28px;
+  --fs-h1: 40px;
+  --lh-tight: 1.15;
+  --lh-snug: 1.35;
+  --lh-body: 1.55;
+  --ls-caps: 0.12em;
+  --sp-1: 4px;
+  --sp-2: 8px;
+  --sp-3: 12px;
+  --sp-4: 16px;
+  --sp-5: 20px;
+  --sp-6: 24px;
+  --sp-8: 32px;
+  --sp-10: 40px;
+  --r-2: 4px;
+  --r-3: 6px;
+  --r-4: 8px;
+  --r-pill: 999px;
+  --sh-1: 0 1px 0 rgba(0, 0, 0, 0.22), 0 0 0 1px var(--border);
+  --sh-2: 0 1px 2px rgba(0, 0, 0, 0.3), 0 0 0 1px var(--border);
+  --sh-focus: 0 0 0 3px rgba(75, 142, 203, 0.33);
+  --sh-inset: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+}
+
+:root[data-theme="light"] {
   --paper: #f4f3ef;
   --paper-2: #ecebe6;
   --paper-3: #e3e2dc;
@@ -81,31 +139,6 @@
   --border: #d8d6cf;
   --border-soft: #e3e2dc;
   --border-strong: #b9b6ad;
-  --font-slab: "Courier Prime", "Courier New", ui-monospace, monospace;
-  --font-sans: "IBM Plex Sans", "Segoe UI", system-ui, sans-serif;
-  --font-mono: "IBM Plex Mono", "Courier Prime", ui-monospace, monospace;
-  --fs-eyebrow: 12px;
-  --fs-small: 13px;
-  --fs-body: 14px;
-  --fs-h3: 20px;
-  --fs-h2: 28px;
-  --fs-h1: 40px;
-  --lh-tight: 1.15;
-  --lh-snug: 1.35;
-  --lh-body: 1.55;
-  --ls-caps: 0.12em;
-  --sp-1: 4px;
-  --sp-2: 8px;
-  --sp-3: 12px;
-  --sp-4: 16px;
-  --sp-5: 20px;
-  --sp-6: 24px;
-  --sp-8: 32px;
-  --sp-10: 40px;
-  --r-2: 4px;
-  --r-3: 6px;
-  --r-4: 8px;
-  --r-pill: 999px;
   --sh-1: 0 1px 0 rgba(28, 28, 26, 0.04), 0 0 0 1px var(--border);
   --sh-2: 0 1px 2px rgba(28, 28, 26, 0.05), 0 0 0 1px var(--border);
   --sh-focus: 0 0 0 3px rgba(26, 58, 92, 0.25);
@@ -119,6 +152,14 @@
 html,
 body {
   min-height: 100%;
+}
+
+html {
+  color-scheme: dark;
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
 }
 
 body {
@@ -208,6 +249,16 @@ code {
 .version-chip {
   font-size: var(--fs-small);
   color: var(--ink-soft);
+}
+
+.theme-toggle {
+  margin-left: auto;
+  border: 1px solid var(--border);
+  background: var(--paper-2);
+  color: var(--ink);
+  border-radius: var(--r-pill);
+  padding: 6px 12px;
+  font-size: var(--fs-small);
 }
 
 .subtitle {

--- a/assets/app.js
+++ b/assets/app.js
@@ -892,13 +892,31 @@
     return page;
   }
 
+  const INDEX_PAGE_WIDTH = 612;
+  const INDEX_PAGE_HEIGHT = 792;
+  const INDEX_TITLE_Y_OFFSET = 74;
+  const INDEX_START_Y_OFFSET = 112;
+  const INDEX_ROW_HEIGHT = 22;
+  const INDEX_BOTTOM_MARGIN = 48;
+
+  function getIndexEntriesPerPage() {
+    return Math.floor(
+      ((INDEX_PAGE_HEIGHT - INDEX_START_Y_OFFSET) - INDEX_BOTTOM_MARGIN) / INDEX_ROW_HEIGHT,
+    ) + 1;
+  }
+
+  function getIndexPageCount(entryCount) {
+    const entriesPerPage = getIndexEntriesPerPage();
+    return Math.max(1, Math.ceil(entryCount / entriesPerPage));
+  }
+
   function buildIndexEntries() {
     let nextPage = 1;
     if (state.cover.includeCover) {
       nextPage += 1;
     }
     if (state.pagination.includeIndexPage) {
-      nextPage += 1;
+      nextPage += getIndexPageCount(state.documents.length);
     }
 
     return state.documents.map((documentRecord) => {
@@ -912,44 +930,57 @@
   }
 
   function renderIndexPage(pdfDoc, coverFonts, indexEntries) {
-    const page = pdfDoc.addPage([612, 792]);
-    const { width, height } = page.getSize();
     const { bodyFont, bodyBoldFont } = coverFonts;
+    const pageSize = [INDEX_PAGE_WIDTH, INDEX_PAGE_HEIGHT];
+    const entriesPerPage = getIndexEntriesPerPage();
+    let firstPage = null;
 
-    page.drawText("DOCUMENT INDEX", {
-      x: 48,
-      y: height - 74,
-      size: 18,
-      font: bodyBoldFont,
-      color: window.PDFLib.rgb(0.11, 0.11, 0.1),
-    });
+    for (let startIndex = 0; startIndex < indexEntries.length || startIndex === 0; startIndex += entriesPerPage) {
+      const page = pdfDoc.addPage(pageSize);
+      const { width, height } = page.getSize();
+      let y = height - INDEX_START_Y_OFFSET;
 
-    let y = height - 112;
-    indexEntries.forEach((entry, index) => {
-      const label = `${index + 1}. ${entry.name}`;
-      const pageLabel = `Page ${entry.startPage}`;
+      if (!firstPage) {
+        firstPage = page;
+      }
 
-      page.drawText(label, {
+      page.drawText("DOCUMENT INDEX", {
         x: 48,
-        y,
-        size: 11,
-        font: bodyFont,
-        color: window.PDFLib.rgb(0.11, 0.11, 0.1),
-        maxWidth: width - 170,
-      });
-
-      page.drawText(pageLabel, {
-        x: width - 124,
-        y,
-        size: 11,
+        y: height - INDEX_TITLE_Y_OFFSET,
+        size: 18,
         font: bodyBoldFont,
-        color: window.PDFLib.rgb(0.42, 0.43, 0.45),
+        color: window.PDFLib.rgb(0.11, 0.11, 0.1),
       });
 
-      y -= 22;
-    });
+      indexEntries
+        .slice(startIndex, startIndex + entriesPerPage)
+        .forEach((entry, pageEntryIndex) => {
+          const index = startIndex + pageEntryIndex;
+          const label = `${index + 1}. ${entry.name}`;
+          const pageLabel = `Page ${entry.startPage}`;
 
-    return page;
+          page.drawText(label, {
+            x: 48,
+            y,
+            size: 11,
+            font: bodyFont,
+            color: window.PDFLib.rgb(0.11, 0.11, 0.1),
+            maxWidth: width - 170,
+          });
+
+          page.drawText(pageLabel, {
+            x: width - 124,
+            y,
+            size: 11,
+            font: bodyBoldFont,
+            color: window.PDFLib.rgb(0.42, 0.43, 0.45),
+          });
+
+          y -= INDEX_ROW_HEIGHT;
+        });
+    }
+
+    return firstPage;
   }
 
   async function ensureOcrWorker() {

--- a/assets/app.js
+++ b/assets/app.js
@@ -27,9 +27,10 @@
       startNumber: 1,
       position: "bottom-right",
       ocrMode: "auto",
-      skipCover: true,
-      outputFilename: "dossier-bundle.pdf",
+      includeIndexPage: false,
+      outputFilename: "bundle-builder.pdf",
     },
+    theme: "dark",
     output: {
       url: "",
       filename: "",
@@ -87,8 +88,9 @@
     pagePosition: document.getElementById("pagePosition"),
     applyPagination: document.getElementById("applyPagination"),
     ocrMode: document.getElementById("ocrMode"),
-    skipCoverPagination: document.getElementById("skipCoverPagination"),
+    includeIndexPage: document.getElementById("includeIndexPage"),
     outputFilename: document.getElementById("outputFilename"),
+    themeToggle: document.getElementById("themeToggle"),
     buildBundleButton: document.getElementById("buildBundleButton"),
     exportSummaryText: document.getElementById("exportSummaryText"),
     downloadLink: document.getElementById("downloadLink"),
@@ -189,7 +191,7 @@
   }
 
   function normalizeFilename(filename) {
-    const trimmed = (filename || "").trim() || "dossier-bundle";
+    const trimmed = (filename || "").trim() || "bundle-builder";
     return trimmed.toLowerCase().endsWith(".pdf") ? trimmed : `${trimmed}.pdf`;
   }
 
@@ -210,8 +212,8 @@
     state.pagination.startNumber = Number.isFinite(parsedStart) && parsedStart > 0 ? parsedStart : 1;
     state.pagination.position = elements.pagePosition.value;
     state.pagination.ocrMode = elements.ocrMode.value;
-    state.pagination.skipCover = elements.skipCoverPagination.checked;
-    state.pagination.outputFilename = elements.outputFilename.value.trim() || "dossier-bundle.pdf";
+    state.pagination.includeIndexPage = elements.includeIndexPage.checked;
+    state.pagination.outputFilename = elements.outputFilename.value.trim() || "bundle-builder.pdf";
   }
 
   function syncFormState() {
@@ -254,6 +256,34 @@
     )} queued`;
     elements.coverPreviewPageCount.textContent = `${formatCount(totalPages, "page", "pages")}`;
     elements.coverPreviewNote.textContent = state.cover.note;
+  }
+
+  function setTheme(theme) {
+    const nextTheme = theme === "light" ? "light" : "dark";
+    state.theme = nextTheme;
+    document.documentElement.dataset.theme = nextTheme;
+    elements.themeToggle.textContent = nextTheme === "dark" ? "Switch to light mode" : "Switch to dark mode";
+    elements.themeToggle.setAttribute("aria-pressed", String(nextTheme === "light"));
+
+    try {
+      window.localStorage.setItem("bundleBuilderTheme", nextTheme);
+    } catch (error) {
+      console.warn("Could not persist theme preference.", error);
+    }
+  }
+
+  function loadThemePreference() {
+    try {
+      const savedTheme = window.localStorage.getItem("bundleBuilderTheme");
+      if (savedTheme === "light" || savedTheme === "dark") {
+        setTheme(savedTheme);
+        return;
+      }
+    } catch (error) {
+      console.warn("Could not read theme preference.", error);
+    }
+
+    setTheme("dark");
   }
 
   function switchTab(nextTab) {
@@ -486,7 +516,7 @@
       : "No merged PDF has been built yet.";
 
     elements.downloadLink.href = hasOutput ? state.output.url : "#";
-    elements.downloadLink.download = state.output.filename || "dossier-bundle.pdf";
+    elements.downloadLink.download = state.output.filename || "bundle-builder.pdf";
     elements.downloadLink.classList.toggle("is-disabled", !hasOutput);
     elements.downloadLink.setAttribute("aria-disabled", hasOutput ? "false" : "true");
 
@@ -862,6 +892,66 @@
     return page;
   }
 
+  function buildIndexEntries() {
+    let nextPage = 1;
+    if (state.cover.includeCover) {
+      nextPage += 1;
+    }
+    if (state.pagination.includeIndexPage) {
+      nextPage += 1;
+    }
+
+    return state.documents.map((documentRecord) => {
+      const entry = {
+        name: documentRecord.name,
+        startPage: nextPage,
+      };
+      nextPage += documentRecord.pageCount;
+      return entry;
+    });
+  }
+
+  function renderIndexPage(pdfDoc, coverFonts, indexEntries) {
+    const page = pdfDoc.addPage([612, 792]);
+    const { width, height } = page.getSize();
+    const { bodyFont, bodyBoldFont } = coverFonts;
+
+    page.drawText("DOCUMENT INDEX", {
+      x: 48,
+      y: height - 74,
+      size: 18,
+      font: bodyBoldFont,
+      color: window.PDFLib.rgb(0.11, 0.11, 0.1),
+    });
+
+    let y = height - 112;
+    indexEntries.forEach((entry, index) => {
+      const label = `${index + 1}. ${entry.name}`;
+      const pageLabel = `Page ${entry.startPage}`;
+
+      page.drawText(label, {
+        x: 48,
+        y,
+        size: 11,
+        font: bodyFont,
+        color: window.PDFLib.rgb(0.11, 0.11, 0.1),
+        maxWidth: width - 170,
+      });
+
+      page.drawText(pageLabel, {
+        x: width - 124,
+        y,
+        size: 11,
+        font: bodyBoldFont,
+        color: window.PDFLib.rgb(0.42, 0.43, 0.45),
+      });
+
+      y -= 22;
+    });
+
+    return page;
+  }
+
   async function ensureOcrWorker() {
     if (state.ocrWorker) {
       return state.ocrWorker;
@@ -970,6 +1060,7 @@
       const titleFont = await mergedPdf.embedFont(StandardFonts.CourierBold);
       const bodyFont = await mergedPdf.embedFont(StandardFonts.Helvetica);
       const bodyBoldFont = await mergedPdf.embedFont(StandardFonts.HelveticaBold);
+      const indexEntries = buildIndexEntries();
 
       let nextPageNumber = state.pagination.startNumber;
       let ocrAppliedPages = 0;
@@ -980,14 +1071,28 @@
         const coverPage = renderCoverPage(mergedPdf, { titleFont, bodyFont, bodyBoldFont });
         addLog("Added generated cover page.");
 
-        if (state.pagination.applyPagination && !state.pagination.skipCover) {
+        if (state.pagination.applyPagination) {
           renderPageNumber(coverPage, nextPageNumber, bodyFont);
           nextPageNumber += 1;
         }
       }
 
-      for (const documentRecord of state.documents) {
+      if (state.pagination.includeIndexPage) {
+        const indexPage = renderIndexPage(mergedPdf, { titleFont, bodyFont, bodyBoldFont }, indexEntries);
+        addLog("Added document index page.");
+
+        if (state.pagination.applyPagination) {
+          renderPageNumber(indexPage, nextPageNumber, bodyFont);
+          nextPageNumber += 1;
+        }
+      }
+
+      for (const [docIndex, documentRecord] of state.documents.entries()) {
         addLog(`Merging ${documentRecord.name}.`);
+        const indexEntry = indexEntries[docIndex];
+        if (indexEntry) {
+          addLog(`Bookmark: ${indexEntry.name} starts on page ${indexEntry.startPage}.`);
+        }
 
         const sourcePdf = await PDFDocument.load(documentRecord.bytes.slice(), {
           ignoreEncryption: true,
@@ -1155,11 +1260,15 @@
       elements.pagePosition,
       elements.applyPagination,
       elements.ocrMode,
-      elements.skipCoverPagination,
+      elements.includeIndexPage,
       elements.outputFilename,
     ].forEach((field) => {
       field.addEventListener("input", updateAfterInputChange);
       field.addEventListener("change", updateAfterInputChange);
+    });
+
+    elements.themeToggle.addEventListener("click", () => {
+      setTheme(state.theme === "dark" ? "light" : "dark");
     });
 
     elements.buildBundleButton.addEventListener("click", () => {
@@ -1188,6 +1297,7 @@
   }
 
   function init() {
+    loadThemePreference();
     updateSummary();
     renderQueueList();
     renderReviewList();

--- a/assets/app.js
+++ b/assets/app.js
@@ -1091,7 +1091,7 @@
         addLog(`Merging ${documentRecord.name}.`);
         const indexEntry = indexEntries[docIndex];
         if (indexEntry) {
-          addLog(`Bookmark: ${indexEntry.name} starts on page ${indexEntry.startPage}.`);
+          addLog(`Index: ${indexEntry.name} starts on page ${indexEntry.startPage}.`);
         }
 
         const sourcePdf = await PDFDocument.load(documentRecord.bytes.slice(), {

--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="Dossier Builder is a portable offline PDF bundling tool with local OCR, review, cover page, and pagination controls."
+      content="Bundle Builder is a portable offline PDF bundling tool with local OCR, review, cover page, and pagination controls."
     />
-    <title>Dossier Builder</title>
+    <title>Bundle Builder</title>
     <link rel="stylesheet" href="./assets/app.css" />
     <script src="./libs/pdf.min.js" defer></script>
     <script src="./libs/pdf-lib.min.js" defer></script>
@@ -19,8 +19,9 @@
       <header class="app-header">
         <div class="eyebrow"><span class="brand-line" aria-hidden="true"></span>Coroner's Office Tooling</div>
         <div class="title-row">
-          <h1>Dossier Builder</h1>
+          <h1>Bundle Builder</h1>
           <span class="version-chip">v2.0</span>
+          <button class="theme-toggle" id="themeToggle" type="button" aria-pressed="false">Switch to light mode</button>
         </div>
         <p class="subtitle">Portable PDF bundling. No network. Files stay on this machine.</p>
 
@@ -346,16 +347,17 @@
                   </label>
 
                   <label class="checkbox-row">
-                    <input id="skipCoverPagination" type="checkbox" checked />
+                    <input id="includeIndexPage" type="checkbox" />
                     <span>
-                      <strong>Start numbering after the cover page</strong><br />
-                      <span class="field-hint">If the cover page is not included, numbering starts on the first source page.</span>
+                      <strong>Add document index page</strong><br />
+                      <span class="field-hint">Adds an index page that lists each queued document and its starting page.</span>
                     </span>
                   </label>
 
+
                   <div class="field">
                     <label for="outputFilename">Output filename</label>
-                    <input id="outputFilename" type="text" value="dossier-bundle.pdf" />
+                    <input id="outputFilename" type="text" value="bundle-builder.pdf" />
                   </div>
 
                   <div class="button-row">
@@ -381,7 +383,7 @@
                   <p class="meta-text" id="exportSummaryText">No merged PDF has been built yet.</p>
 
                   <div class="result-links">
-                    <a class="button button-primary is-disabled" id="downloadLink" href="#" download="dossier-bundle.pdf" aria-disabled="true">
+                    <a class="button button-primary is-disabled" id="downloadLink" href="#" download="bundle-builder.pdf" aria-disabled="true">
                       Download merged PDF
                     </a>
                     <a class="button button-secondary is-disabled" id="openLink" href="#" target="_blank" rel="noopener" aria-disabled="true">


### PR DESCRIPTION
### Motivation
- Update the product name and metadata from “Dossier Builder” to “Bundle Builder” for UI and documentation consistency.
- Provide an option to include a generated index page that lists each queued document and its starting page to aid navigation of merged bundles.
- Simplify pagination behavior so the cover page is always counted as page 1 and add a dark/light theme toggle that defaults to dark for better UX in low-light environments.

### Description
- Renamed UI and metadata strings in `index.html` and `README.md` from `Dossier Builder` to `Bundle Builder` and updated default filenames to `bundle-builder.pdf` and `bundle-builder` in `assets/app.js`.
- Replaced the previous "Start numbering after the cover page" control by removing `skipCoverPagination` and adding an `includeIndexPage` checkbox and `state.pagination.includeIndexPage` control to the form and state.
- Implemented index generation with `buildIndexEntries()` and `renderIndexPage()` in `assets/app.js`, and wired inclusion of the index page (and its pagination) into `buildBundle()` so the index shows each document name and its computed start page.
- Added theme support: `setTheme()`/`loadThemePreference()` and a header toggle button (`#themeToggle`) with CSS variables and tokens in `assets/app.css` to provide a dark default and a `data-theme="light"` override.

### Testing
- Ran `node --check assets/app.js` to validate JavaScript syntax and it completed without errors. 
- No automated UI or integration tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6137b16708324982444449c8f43f9)