### PR TITLE
Disable Tesseract blob worker wrapper to avoid importScripts NetworkError

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -103,6 +103,7 @@
     workerPath: new URL("./runtime/tesseract/worker.min.js", window.location.href).toString(),
     corePath: new URL("./runtime/tesseract-core/", window.location.href).toString(),
     langPath: new URL("./runtime/tessdata/", window.location.href).toString(),
+    workerBlobURL: false,
   };
 
   if (window.pdfjsLib && window.pdfjsLib.GlobalWorkerOptions) {
@@ -1016,6 +1017,7 @@
         workerPath: ocrRuntime.workerPath,
         corePath: ocrRuntime.corePath,
         langPath: ocrRuntime.langPath,
+        workerBlobURL: ocrRuntime.workerBlobURL,
         logger: (message) => {
           if (!state.busy || !state.currentOcrLabel) {
             return;


### PR DESCRIPTION
### Motivation
- Some environments fail to load the blob bootstrap used by Tesseract (causing `NetworkError: Failed to execute 'importScripts' on 'WorkerGlobalScope'`), so the worker should be created from the direct script URL instead of via a blob wrapper.

### Description
- Add `workerBlobURL: false` to the `ocrRuntime` configuration to disable Tesseract's blob-based worker bootstrap.
- Pass `workerBlobURL: ocrRuntime.workerBlobURL` through to `Tesseract.createWorker(...)` so the worker is instantiated from the direct `workerPath` URL.

### Testing
- Ran `node --check assets/app.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e64901fe6c83248247feac2b1f48e7)