### PR TITLE
Use PDF invisible text rendering mode for OCR overlays

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1023,6 +1023,8 @@
 
   function addInvisibleTextLayer(pdfPage, viewport, ocrData, bodyFont) {
     const textItems = Array.isArray(ocrData.lines) && ocrData.lines.length > 0 ? ocrData.lines : ocrData.words || [];
+    const hasRenderingModeSupport =
+      typeof window.PDFLib.setTextRenderingMode === "function" && typeof pdfPage.pushOperators === "function";
 
     textItems.forEach((item) => {
       const text = String(item.text || "").replace(/\s+/g, " ").trim();
@@ -1047,18 +1049,27 @@
       const height = Math.max(6, Math.abs(yHigh - yLow));
       const fontSize = Math.max(6, height * 0.85);
 
-      // pdf-lib does not expose PDF text rendering modes (e.g. invisible text).
-      // Using near-zero opacity keeps text invisible on-screen while still
-      // making it selectable and searchable in supporting PDF viewers.
+      if (hasRenderingModeSupport) {
+        // Render mode 3 = invisible text. This keeps OCR text searchable
+        // without relying on near-transparent fill opacity, which many
+        // viewers ignore for indexing/search.
+        pdfPage.pushOperators(window.PDFLib.setTextRenderingMode(3));
+      }
+
       pdfPage.drawText(text, {
         x,
         y: yLow + height * 0.08,
         size: fontSize,
         font: bodyFont,
         maxWidth: width,
-        color: window.PDFLib.rgb(1, 1, 1),
-        opacity: 0.001,
+        color: window.PDFLib.rgb(0, 0, 0),
+        opacity: 1,
       });
+
+      if (hasRenderingModeSupport) {
+        // Reset render mode for any later visible text additions.
+        pdfPage.pushOperators(window.PDFLib.setTextRenderingMode(0));
+      }
     });
   }
 

--- a/assets/app.js
+++ b/assets/app.js
@@ -1062,8 +1062,8 @@
         size: fontSize,
         font: bodyFont,
         maxWidth: width,
-        color: window.PDFLib.rgb(0, 0, 0),
-        opacity: 1,
+        color: hasRenderingModeSupport ? window.PDFLib.rgb(0, 0, 0) : window.PDFLib.rgb(1, 1, 1),
+        opacity: hasRenderingModeSupport ? 1 : 0.01,
       });
 
       if (hasRenderingModeSupport) {

--- a/assets/app.js
+++ b/assets/app.js
@@ -1026,7 +1026,7 @@
     const hasRenderingModeSupport =
       typeof window.PDFLib.setTextRenderingMode === "function" && typeof pdfPage.pushOperators === "function";
 
-    textItems.forEach((item) => {
+    const drawTextItem = (item) => {
       const text = String(item.text || "").replace(/\s+/g, " ").trim();
       const bbox = item.bbox || item;
 
@@ -1049,13 +1049,6 @@
       const height = Math.max(6, Math.abs(yHigh - yLow));
       const fontSize = Math.max(6, height * 0.85);
 
-      if (hasRenderingModeSupport) {
-        // Render mode 3 = invisible text. This keeps OCR text searchable
-        // without relying on near-transparent fill opacity, which many
-        // viewers ignore for indexing/search.
-        pdfPage.pushOperators(window.PDFLib.setTextRenderingMode(3));
-      }
-
       pdfPage.drawText(text, {
         x,
         y: yLow + height * 0.08,
@@ -1065,12 +1058,23 @@
         color: hasRenderingModeSupport ? window.PDFLib.rgb(0, 0, 0) : window.PDFLib.rgb(1, 1, 1),
         opacity: hasRenderingModeSupport ? 1 : 0.01,
       });
+    };
 
-      if (hasRenderingModeSupport) {
-        // Reset render mode for any later visible text additions.
-        pdfPage.pushOperators(window.PDFLib.setTextRenderingMode(0));
-      }
-    });
+    if (!hasRenderingModeSupport) {
+      textItems.forEach(drawTextItem);
+      return;
+    }
+
+    // Render mode 3 = invisible text. This keeps OCR text searchable
+    // without relying on near-transparent fill opacity, which many
+    // viewers ignore for indexing/search.
+    pdfPage.pushOperators(window.PDFLib.setTextRenderingMode(3));
+    try {
+      textItems.forEach(drawTextItem);
+    } finally {
+      // Reset render mode for any later visible text additions.
+      pdfPage.pushOperators(window.PDFLib.setTextRenderingMode(0));
+    }
   }
 
   async function buildBundle() {


### PR DESCRIPTION
### Motivation
- OCR progress indicated recognition was running but merged PDFs still lacked selectable/searchable text because the overlay used a near-transparent fill which some viewers/indexers ignore. 
- The goal is to make OCR text invisible to viewers while remaining indexable/searchable in the PDF output using a proper PDF text rendering mode.

### Description
- Added a feature-detection check (`hasRenderingModeSupport`) to detect whether the PDF operator APIs are available at runtime. 
- When supported, the code now calls `setTextRenderingMode(3)` via `pdfPage.pushOperators(...)` before drawing OCR text to mark it as invisible, and resets to `setTextRenderingMode(0)` afterward. 
- Replaced the previous near-transparent draw approach with normal text drawing when render-mode operators are used so the text is indexed by PDF viewers that honour invisible text rendering.
- The change is implemented in `assets/app.js` inside `addInvisibleTextLayer` so OCR overlays on merged pages are applied with the invisible text rendering mode when available.

### Testing
- Ran a syntax check with `node --check assets/app.js`, which completed successfully. 
- Verified the modified `assets/app.js` was updated and the application code loads without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e72af83a108324ba3f9c0a957cd898)